### PR TITLE
Added SuppressWarnings to exception list, to be not treated like a..

### DIFF
--- a/Plugin/Annotation/SymfonyAnnotationPlugin.php
+++ b/Plugin/Annotation/SymfonyAnnotationPlugin.php
@@ -41,7 +41,8 @@ class SymfonyAnnotationVisitor extends AnnotationVisitor
    */
   protected $exceptions = [
       'Annotation',
-      'Target'
+      'Target',
+      'SuppressWarnings'
   ];
 }
 


### PR DESCRIPTION
…symfony annotation.

Don't really know what I did, but solves the problem, in my environment @SurpressWarning Anotations do not lead to false positives any more.