### PR TITLE
Ignore .html.twig for Template annotation

### DIFF
--- a/Helper/NamespaceChecker.php
+++ b/Helper/NamespaceChecker.php
@@ -96,7 +96,7 @@ class NamespaceChecker
     while ($type instanceof GenericArrayType) {
       $type = $type->genericArrayElementType();
     }
-    if ($type->isNativeType() || ($type->isSelfType() | $type->isStaticType())) {
+    if ($type->isNativeType() || ($type->isSelfType() || $type->isStaticType())) {
       return NULL;
     }
     if ($type instanceof TemplateType) {

--- a/Plugin/Annotation/Base/AnnotationVisitor.php
+++ b/Plugin/Annotation/Base/AnnotationVisitor.php
@@ -22,7 +22,7 @@ abstract class AnnotationVisitor extends PluginAwarePostAnalysisVisitor
 
   const annotation_regex = '/@(' . Type::simple_type_regex . ')[\(]?/';
   const class_name_resolution_regex = '/(' . Type::simple_type_regex . ')::class/';
-  const const_reference_regex = '/(' . Type::simple_type_regex . ')::([a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)/';
+  const const_reference_regex = '/(' . Type::simple_type_regex . ')::([a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*)(\.html\.twig)?/';
 
   /**
    * Holds the exceptions for a specific framework
@@ -118,6 +118,11 @@ abstract class AnnotationVisitor extends PluginAwarePostAnalysisVisitor
       // Test if not class constant
       $const = $matches[3][$key];
       if ($const === 'class') {
+        continue;
+      }
+
+      // Test if not .html.twig
+      if (($matches[4][$key] ?? '') === '.html.twig'){
         continue;
       }
 

--- a/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/013_constant_reference.php
+++ b/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/013_constant_reference.php
@@ -5,7 +5,7 @@ namespace Some\Name\Space;
 use Annotations\Number1;
 use Constants\Properties;
 
-class Class014
+class Class013
 {
 
   /**

--- a/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/014_constant_reference_does_not_exist_with_namespace.php
+++ b/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/014_constant_reference_does_not_exist_with_namespace.php
@@ -5,7 +5,7 @@ namespace Some\Name\Space;
 use Annotations\Number1;
 use Constants\Properties;
 
-class Class013
+class Class014
 {
 
   /**

--- a/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/015_ignore_contstant_reference_if_containts_html_twig.php
+++ b/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/015_ignore_contstant_reference_if_containts_html_twig.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Some\Name\Space;
+
+use Annotations\Template;
+
+class Class015
+{
+
+  /**
+   * @Template("SomeBundle::some_template.html.twig")
+   */
+  public $x;
+}

--- a/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/Annotations.php
+++ b/tests/Plugin/Annotation/SymfonyAnnotationPlugin/src/Annotations.php
@@ -10,10 +10,16 @@ namespace Annotations {
   {
 
   }
+
+  class Template
+  {
+
+  }
 }
 
 namespace Constants {
-  class Properties {
+  class Properties
+  {
     const TEST = true;
   }
 }


### PR DESCRIPTION
Some old `Template` annotation would falsely trigger an error during analysis:

For example, 
```
@Template("IdbDogroupBundle::uploadMCData.html.twig")
```

Would trigger:
```
src/Idb/DogroupBundle/Controller/StudyCombinationController.php:491 ConstReferenceClassNotImported The classlike \Idb\DogroupBundle\Controller\IdbDogroupBundle used in IdbDogroupBundle::uploadMCData is undeclared (generated by DrensoAnnotation plugin)
```